### PR TITLE
打刻情報通知の文言をカスタマイズした

### DIFF
--- a/app/slack.go
+++ b/app/slack.go
@@ -38,7 +38,7 @@ func (ctx *Context) getActionCallback(data *slack.AttachmentActionCallback) (*sl
 	case actionTypeLeave:
 		{
 			attendance = 0
-			text = "退勤しました :house:"
+			text = "おつかれさまでした :house:"
 		}
 	case actionTypeRest:
 		{

--- a/app/slack.go
+++ b/app/slack.go
@@ -53,7 +53,7 @@ func (ctx *Context) getActionCallback(data *slack.AttachmentActionCallback) (*sl
 	case actionTypeAttend:
 		{
 			attendance = 1
-			text = "出勤しました :office:"
+			text = "おはようございます :sun_with_face:"
 		}
 	}
 


### PR DESCRIPTION
## :sparkles: 目的

打刻したら`#general`チャンネルに`おはようございます🌞`や`おつかれさまでした🏠`が通知されると便利である。
これに対応する。

## :muscle: 方針

通知の文言を変更する。

## :white_check_mark: テスト

Siderが通ることだけ確認した。